### PR TITLE
Adding Github links and last date modified

### DIFF
--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -21,7 +21,7 @@ site_author: WSO2
 site_url: https://si.docs.wso2.com/
 
 # Repository information
-repo_name: wso2/docs-streaming-integrator
+repo_name: wso2/docs-si
 repo_url: https://github.com/wso2/docs-si
 edit_uri: https://github.com/wso2/docs-si/edit/main/en/docs/
 dev_addr: localhost:8000
@@ -331,6 +331,9 @@ plugins:
         - wip/*
   - redirects:
       redirect_maps:
+  - git-revision-date-localized:
+      type: date
+      fallback_to_build_date: true
 
 # Extra configuration
 extra_css:
@@ -338,6 +341,7 @@ extra_css:
     - assets/css/theme.css
     - assets/css/copy-page.css
     - assets/lib/json-formatter/json-formatter.css
+    - assets/css/actions.css
 extra_javascript:
     - assets/lib/json-formatter/json-formatter.umd.js
     - assets/lib/highlightjs/highlight.min.js

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -342,6 +342,7 @@ extra_css:
     - assets/css/copy-page.css
     - assets/lib/json-formatter/json-formatter.css
     - assets/css/actions.css
+    - assets/css/source.css
 extra_javascript:
     - assets/lib/json-formatter/json-formatter.umd.js
     - assets/lib/highlightjs/highlight.min.js

--- a/en/requirements.txt
+++ b/en/requirements.txt
@@ -11,4 +11,5 @@ markdown==3.2.1
 mkdocs-exclude==1.0.2
 jinja2==3.1.2
 mike==2.1.3
+mkdocs-git-revision-date-localized-plugin==1.2.6
 setuptools==78.1.1

--- a/en/theme/material/assets/css/actions.css
+++ b/en/theme/material/assets/css/actions.css
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/* Per-page footer row: "Edit this page" (left) + "Last update …" (right) */
+
+.md-content__footer {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.4rem 1.2rem;
+  margin-top: 1rem;
+  font-size: 0.75rem;
+}
+
+/* Suppress the <hr> that upstream's source-file.html emits internally —
+   the content.html shadow renders one above the whole footer row. */
+.md-content__footer > hr {
+  display: none;
+}
+
+.md-content__footer .md-source-file {
+  margin-left: auto;
+}
+
+.md-content__action-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4em;
+  color: var(--md-default-fg-color--light);
+  text-decoration: none;
+  transition: color 0.15s ease;
+}
+
+.md-content__action-link:hover,
+.md-content__action-link:focus {
+  color: var(--md-typeset-a-color);
+  text-decoration: underline;
+}
+
+.md-content__action-link svg {
+  width: 14px;
+  height: 14px;
+  fill: currentColor;
+  flex-shrink: 0;
+}
+
+/* Dark mode */
+[data-md-color-scheme="slate"] .md-content__action-link {
+  color: var(--md-default-fg-color--light);
+}
+
+[data-md-color-scheme="slate"] .md-content__action-link:hover,
+[data-md-color-scheme="slate"] .md-content__action-link:focus {
+  color: var(--md-typeset-a-color);
+}

--- a/en/theme/material/assets/css/source.css
+++ b/en/theme/material/assets/css/source.css
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/* GitHub repo link in the header (renders via partials/source.html).
+   We deliberately do not use Material's `.md-header__source` class —
+   upstream styles it with a fixed 11.7rem width for the stock repo
+   widget, which would leave a wide empty gap around our single icon. */
+
+.md-header__github {
+  display: flex;
+  align-items: center;
+}
+
+.md-header__github-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.md-header__github-link svg {
+  width: 1.2rem;
+  height: 1.2rem;
+  fill: currentColor;
+}
+
+/* Cancel the stock 15px `margin-right` from `.md-header__button` so the
+   github icon sits flush against the theme toggle. */
+.md-header__github-link.md-header__button {
+  margin-right: 0;
+}

--- a/en/theme/material/customizations.md
+++ b/en/theme/material/customizations.md
@@ -20,7 +20,9 @@ partials/tabs-item.html
 partials/nav.html
 partials/actions.html
 partials/content.html
+partials/source.html
 assets/css/actions.css
+assets/css/source.css
 ```
 
 ### Per-page footer row: "Edit this page" link + "Last update" timestamp
@@ -39,6 +41,10 @@ If the upstream `content.html` is updated in a future `mkdocs-material` version,
 The "Last update" timestamp is rendered by Material's stock `partials/source-file.html` (no override needed) when the `git-revision-date-localized` plugin is active. The plugin is wired up in `mkdocs.yml` under `plugins:` and pinned in `requirements.txt` (`mkdocs-git-revision-date-localized-plugin`). `fallback_to_build_date: true` keeps the build green for files not yet committed.
 
 Styling lives in `assets/css/actions.css`, loaded globally via `extra_css` in `en/mkdocs.yml` so it lands in `<head>` alongside the other custom stylesheets. (`report-issues.css` still uses an in-body `<link>` from its partial — that's a pre-existing quirk we have not changed.)
+
+### Header GitHub repo link
+
+`partials/source.html` renders an icon-only GitHub link in the header, pointing at `config.repo_url`. It is included from `partials/header.html` between the community and report-issues blocks. The icon is `fontawesome/brands/github.svg` (resolved at build time from the upstream `mkdocs-material` package's `.icons/`, same way Discord/LinkedIn/YouTube icons in `community.html` resolve). Styling is in `assets/css/source.css` and loaded globally via `extra_css` in `en/mkdocs.yml`. The link is automatically hidden if `repo_url` is unset.
 
 ## Search optimizations (note: the following are generated files)
 

--- a/en/theme/material/customizations.md
+++ b/en/theme/material/customizations.md
@@ -18,7 +18,27 @@ partials/footer.html
 partials/header.html
 partials/tabs-item.html
 partials/nav.html
+partials/actions.html
+partials/content.html
+assets/css/actions.css
 ```
+
+### Per-page footer row: "Edit this page" link + "Last update" timestamp
+
+Below every article body (on pages that extend `main.html`), a small footer row renders the "Edit this page" link on the **left** and the "Last update: …" timestamp on the **right**, separated from the article body by a single horizontal rule. Layout matches the equivalent element on `wso2/docs-integrator`.
+
+`partials/actions.html` renders the link with the Material pencil icon. Link target is `page.edit_url` with `/edit/` (or `/blob/`) rewritten to `/tree/`, so it derives automatically from `repo_url` + `edit_uri` in `mkdocs.yml` rather than being hardcoded. As long as `edit_uri` points at GitHub, the link follows the file on rename/move and re-renders correctly on every build.
+
+`partials/content.html` is a local shadow of the upstream copy bundled with `mkdocs-material`. It differs in two ways:
+
+1. The top-of-content `{% include "partials/actions.html" %}` is removed (upstream renders it above the article — we don't want that).
+2. After `{{ page.content }}`, an `<hr>` is emitted, followed by a `<div class="md-content__footer">` flex row that wraps `{% include "partials/actions.html" %}` and `{% include "partials/source-file.html" %}`. CSS in `assets/css/actions.css` lays them out side-by-side (`margin-left: auto` on `.md-source-file` pushes the date to the right) and hides the `<hr>` that `source-file.html` itself emits, so the row doesn't get a stray divider through the middle.
+
+If the upstream `content.html` is updated in a future `mkdocs-material` version, re-sync this file and re-apply both changes.
+
+The "Last update" timestamp is rendered by Material's stock `partials/source-file.html` (no override needed) when the `git-revision-date-localized` plugin is active. The plugin is wired up in `mkdocs.yml` under `plugins:` and pinned in `requirements.txt` (`mkdocs-git-revision-date-localized-plugin`). `fallback_to_build_date: true` keeps the build green for files not yet committed.
+
+Styling lives in `assets/css/actions.css`, loaded globally via `extra_css` in `en/mkdocs.yml` so it lands in `<head>` alongside the other custom stylesheets. (`report-issues.css` still uses an in-body `<link>` from its partial — that's a pre-existing quirk we have not changed.)
 
 ## Search optimizations (note: the following are generated files)
 

--- a/en/theme/material/partials/actions.html
+++ b/en/theme/material/partials/actions.html
@@ -1,0 +1,32 @@
+<!--
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+-->
+
+{% if page.edit_url %}
+  {%- set _href = page.edit_url | replace('/edit/', '/tree/') | replace('/blob/', '/tree/') -%}
+  <div class="md-content__actions md-typeset">
+    <a class="md-content__action-link"
+       href="{{ _href }}"
+       target="_blank"
+       rel="noopener noreferrer"
+       title="Edit this page on GitHub">
+      {%- set icon = config.theme.icon.edit or "material/file-edit-outline" -%}
+      {% include ".icons/" ~ icon ~ ".svg" %}
+      <span>Edit this page</span>
+    </a>
+  </div>
+{% endif %}

--- a/en/theme/material/partials/content.html
+++ b/en/theme/material/partials/content.html
@@ -1,0 +1,35 @@
+{#-
+  Local override of the upstream `partials/content.html`. Differences from
+  the upstream copy bundled with mkdocs-material:
+
+  1. The top-of-content `{% include "partials/actions.html" %}` is removed
+     (upstream renders it above the article body — we don't want that).
+  2. After `{{ page.content }}`, the "Edit this page" link and the
+     "Last update …" timestamp are wrapped in a single `.md-content__footer`
+     flex row so they sit side-by-side: edit link on the left, date on the
+     right. An `<hr>` is rendered before the row to separate it visually
+     from the article body. The `<hr>` that upstream's `source-file.html`
+     emits internally is suppressed via CSS in `assets/css/actions.css` so
+     the row doesn't get a stray divider through the middle.
+-#}
+{% if "material/tags" in config.plugins %}
+  {% include "partials/tags.html" %}
+{% endif %}
+{% if "\x3ch1" not in page.content %}
+  <h1>{{ page.title | d(config.site_name, true)}}</h1>
+{% endif %}
+{{ page.content }}
+{%- set _has_actions = page.edit_url -%}
+{%- set _has_source = page.meta and (
+  page.meta.git_revision_date_localized or
+  page.meta.revision_date
+) -%}
+{% if _has_actions or _has_source %}
+<hr>
+<div class="md-content__footer">
+  {% if _has_actions %}{% include "partials/actions.html" %}{% endif %}
+  {% if _has_source %}{% include "partials/source-file.html" %}{% endif %}
+</div>
+{% endif %}
+{% include "partials/feedback.html" %}
+{% include "partials/comments.html" %}

--- a/en/theme/material/partials/header.html
+++ b/en/theme/material/partials/header.html
@@ -54,6 +54,7 @@
     </label>
     {% include "partials/search.html" %}
     {% endif %}
+    {% include "partials/source.html" %}
     {% if not config.theme.palette is mapping %}
     <form class="md-header__option" data-md-component="palette">
       {% for option in config.theme.palette %}

--- a/en/theme/material/partials/source.html
+++ b/en/theme/material/partials/source.html
@@ -1,0 +1,30 @@
+<!--
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+-->
+
+{% if config.repo_url %}
+  <div class="md-header__github">
+    <a class="md-header__button md-icon md-icon--hover md-header__github-link"
+       href="{{ config.repo_url }}"
+       target="_blank"
+       rel="noopener noreferrer"
+       title="{{ config.repo_name | d('View on GitHub', true) }}"
+       aria-label="{{ config.repo_name | d('View on GitHub', true) }}">
+      {% include ".icons/fontawesome/brands/github.svg" %}
+    </a>
+  </div>
+{% endif %}


### PR DESCRIPTION
## Purpose
To add Github links directing readers to appropriate pages and also a last date modified section. 

1. Prominent Github link to main documentation repo with logo. 
<img width="668" height="65" alt="Screenshot 2026-04-28 at 15 52 03" src="https://github.com/user-attachments/assets/4b411c8c-1291-4f67-80b2-2c6d9d0aa057" />

2. Individual Github links to each documentation page with individual last date modified per page. 
<img width="631" height="227" alt="Screenshot 2026-04-28 at 15 52 45" src="https://github.com/user-attachments/assets/f9e8dcc9-47c1-405c-9635-5a8ab0a83317" />

## Related PRs
https://github.com/wso2/docs-si/pull/67