### PR TITLE
Remove "Show all" button from version dropdown

### DIFF
--- a/.github/workflows/publish_docs.yaml
+++ b/.github/workflows/publish_docs.yaml
@@ -8,6 +8,7 @@ on:
     branches:
       - main
       - 4.3.0
+      - 4.4.0
   workflow_dispatch:
 
 jobs:
@@ -41,6 +42,9 @@ jobs:
           elif [ "$BRANCH_NAME" = "4.3.0" ]; then
             echo "Deploying 4.3.0 version from 4.3.0 branch"
             mike deploy 4.3.0 -t "4.3.0 and older" --push
+          elif [ "$BRANCH_NAME" = "4.4.0" ]; then
+            echo "Deploying 4.4.0 version from 4.4.0 branch"
+            mike deploy 4.4.0 -t "4.4.0" --push
           else
             echo "Unknown branch: $BRANCH_NAME"
             exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,3 @@ replay_pid*
 # MkDocs build output
 en/site/
 
-# Local versions.json for dev testing (populated via: git show versions:en/docs/assets/versions.json > en/docs/assets/versions.json)
-en/docs/assets/versions.json

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 replay_pid*
+
+# Local versions.json for dev testing (populated via: git show versions:en/docs/assets/versions.json > en/docs/assets/versions.json)
+en/docs/assets/versions.json

--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,8 @@
 hs_err_pid*
 replay_pid*
 
+# MkDocs build output
+en/site/
+
 # Local versions.json for dev testing (populated via: git show versions:en/docs/assets/versions.json > en/docs/assets/versions.json)
 en/docs/assets/versions.json

--- a/en/docs/assets/js/sitheme.js
+++ b/en/docs/assets/js/sitheme.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/en/docs/assets/js/sitheme.js
+++ b/en/docs/assets/js/sitheme.js
@@ -118,11 +118,6 @@ request.onload = function() {
                   dropdown.insertBefore(liElem, dropdown.firstChild);
               }
           });
-
-          var showAllLink = document.getElementById('show-all-versions-link');
-          if (showAllLink) {
-              showAllLink.setAttribute('href', docSetUrl + 'versions');
-          }
       }
 
       /*

--- a/en/docs/assets/js/sitheme.js
+++ b/en/docs/assets/js/sitheme.js
@@ -16,40 +16,25 @@
  * under the License.
  */
 
-// Initialize custom dropdown component
-
-var dropdowns = document.getElementsByClassName('md-tabs__dropdown-link');
-
-function indexInParent(node) {
-    var children = node.parentNode.childNodes;
-    var num = 0;
-    for (var i = 0; i < children.length; i++) {
-        if (children[i] == node) return num;
-        if (children[i].nodeType == 1) num++;
-    }
-    return -1;
-}
-
-for (var i = 0; i < dropdowns.length; i++) {
-    var el = dropdowns[i];
-    var openClass = 'open';
-
-    el.onclick = function () {
-        if (this.parentElement.classList) {
-            this.parentElement.classList.toggle(openClass);
-        } else {
-            var classes = this.parentElement.className.split(' ');
-            var existingIndex = classes.indexOf(openClass);
-
-            if (existingIndex >= 0)
-                classes.splice(existingIndex, 1);
-            else
-                classes.push(openClass);
-
-            this.parentElement.className = classes.join(' ');
+// Initialize version dropdown toggle
+var versionDropdownLink = document.querySelector('.md-header__version-select-dropdown .dropdown-link');
+if (versionDropdownLink) {
+    versionDropdownLink.onclick = function (e) {
+        e.preventDefault();
+        var container = document.getElementById('version-select-container');
+        if (container) {
+            container.classList.toggle('open');
         }
     };
 }
+
+// Close version dropdown when clicking outside
+document.addEventListener('click', function (e) {
+    var container = document.getElementById('version-select-container');
+    if (container && !container.contains(e.target)) {
+        container.classList.remove('open');
+    }
+});
 
 
 /*
@@ -112,7 +97,6 @@ request.onload = function() {
                   }
                   url = url.replace(/\/$/, '') + searchAndHash;
 
-                  liElem.className = 'md-tabs__item mb-tabs__dropdown';
                   liElem.innerHTML = '<a href="' + url + '">' + key + '</a>';
 
                   dropdown.insertBefore(liElem, dropdown.firstChild);

--- a/en/docs/assets/js/sitheme.js
+++ b/en/docs/assets/js/sitheme.js
@@ -50,7 +50,12 @@ var docSetLang = pageHeader ? pageHeader.getAttribute('data-lang') : '';
 var docSetUrl = window.location.origin + '/' + docSetLang;
 var request = new XMLHttpRequest();
 
-request.open('GET', 'https://raw.githubusercontent.com/wso2/docs-si/versions/en/docs/assets/versions.json', true);
+var isLocal = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
+var versionsUrl = isLocal
+    ? '/assets/versions.json'
+    : 'https://raw.githubusercontent.com/wso2/docs-si/versions/en/docs/assets/versions.json';
+
+request.open('GET', versionsUrl, true);
 
 request.onload = function() {
   if (request.status >= 200 && request.status < 400) {

--- a/en/docs/assets/js/sitheme.js
+++ b/en/docs/assets/js/sitheme.js
@@ -1,0 +1,179 @@
+/*!
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Initialize custom dropdown component
+
+var dropdowns = document.getElementsByClassName('md-tabs__dropdown-link');
+
+function indexInParent(node) {
+    var children = node.parentNode.childNodes;
+    var num = 0;
+    for (var i = 0; i < children.length; i++) {
+        if (children[i] == node) return num;
+        if (children[i].nodeType == 1) num++;
+    }
+    return -1;
+}
+
+for (var i = 0; i < dropdowns.length; i++) {
+    var el = dropdowns[i];
+    var openClass = 'open';
+
+    el.onclick = function () {
+        if (this.parentElement.classList) {
+            this.parentElement.classList.toggle(openClass);
+        } else {
+            var classes = this.parentElement.className.split(' ');
+            var existingIndex = classes.indexOf(openClass);
+
+            if (existingIndex >= 0)
+                classes.splice(existingIndex, 1);
+            else
+                classes.push(openClass);
+
+            this.parentElement.className = classes.join(' ');
+        }
+    };
+}
+
+
+/*
+ * Reading versions
+ */
+var pageHeader = document.getElementById('page-header');
+var docSetLang = pageHeader ? pageHeader.getAttribute('data-lang') : '';
+
+(window.location.pathname.split('/')[1] !== docSetLang) ?
+    docSetLang = '' :
+    docSetLang = docSetLang + '/';
+
+var docSetUrl = window.location.origin + '/' + docSetLang;
+var request = new XMLHttpRequest();
+
+request.open('GET', 'https://raw.githubusercontent.com/wso2/docs-si/versions/en/docs/assets/versions.json', true);
+
+request.onload = function() {
+  if (request.status >= 200 && request.status < 400) {
+
+      var data = JSON.parse(request.responseText);
+      var dropdown = document.getElementById('version-select-dropdown');
+      var checkVersionsPage = document.getElementById('current-version-stable');
+
+      /*
+       * Appending versions to the version selector dropdown
+       */
+      if (dropdown) {
+          data.list.sort(function(a, b) {
+              var aParts = a.split('.');
+              var bParts = b.split('.');
+              for (var i = 0; i < Math.max(aParts.length, bParts.length); i++) {
+                  var aPart = parseInt(aParts[i]) || 0;
+                  var bPart = parseInt(bParts[i]) || 0;
+                  if (aPart !== bPart) return aPart - bPart;
+              }
+              return 0;
+          }).forEach(function(key) {
+              var versionData = data.all[key];
+
+              if (versionData) {
+                  var liElem = document.createElement('li');
+                  var currentPath = window.location.pathname;
+                  var langPrefixLength = docSetLang ? docSetLang.length + 1 : 0;
+                  var pathWithoutLang = currentPath.substring(langPrefixLength);
+                  if (pathWithoutLang.startsWith('/')) pathWithoutLang = pathWithoutLang.substring(1);
+
+                  var firstSlashIndex = pathWithoutLang.indexOf('/');
+                  var pathWithoutVersion = (firstSlashIndex !== -1) ? pathWithoutLang.substring(firstSlashIndex) : '/';
+
+                  var versionDoc = data.all[key].doc;
+                  var docLinkType = versionDoc.split(':')[0];
+                  var url = '';
+                  var searchAndHash = window.location.search + window.location.hash;
+
+                  if (docLinkType === 'https' || docLinkType === 'http') {
+                      url = versionDoc.replace(/\/$/, '') + pathWithoutVersion;
+                  } else {
+                      url = docSetUrl + key + pathWithoutVersion;
+                  }
+                  url = url.replace(/\/$/, '') + searchAndHash;
+
+                  liElem.className = 'md-tabs__item mb-tabs__dropdown';
+                  liElem.innerHTML = '<a href="' + url + '">' + key + '</a>';
+
+                  dropdown.insertBefore(liElem, dropdown.firstChild);
+              }
+          });
+
+          var showAllLink = document.getElementById('show-all-versions-link');
+          if (showAllLink) {
+              showAllLink.setAttribute('href', docSetUrl + 'versions');
+          }
+      }
+
+      /*
+       * Appending versions to the version tables in versions page
+       */
+      if (checkVersionsPage) {
+          var previousVersions = [];
+
+          Object.keys(data.all).forEach(function(key) {
+              if ((key !== data.current) && (key !== data['pre-release'])) {
+                  var doc = data.all[key].doc;
+                  var notes = data.all[key].notes;
+                  var target = '_self';
+
+                  if (doc.startsWith('http')) {
+                      target = '_blank';
+                  } else {
+                      doc = (docSetUrl + key + '/' + doc).replace(/([^:]\/)\/+/g, '$1');
+                  }
+
+                  if (notes && !notes.startsWith('http')) {
+                      notes = (docSetUrl + key + '/' + notes).replace(/([^:]\/)\/+/g, '$1');
+                  }
+
+                  previousVersions.push('<tr>' +
+                      '<th>' + key + '</th>' +
+                      '<td><a href="' + doc + '" target="' + target + '">Documentation</a></td>' +
+                      '<td><a href="' + (notes || '#') + '" target="' + target + '">Release Notes</a></td>' +
+                      '</tr>');
+              }
+          });
+
+          document.getElementById('previous-versions').innerHTML = previousVersions.join(' ');
+
+          document.getElementById('current-version-number').innerHTML = data.current;
+          var docDocLink = docSetUrl + data.current;
+          var docNotesLink = data.all[data.current].notes
+              ? docSetUrl + data.all[data.current].notes
+              : docDocLink;
+
+          document.getElementById('current-version-documentation-link').setAttribute('href', docDocLink);
+          document.getElementById('current-version-release-notes-link').setAttribute('href', docNotesLink);
+      }
+
+  } else {
+      console.error('We reached our target server, but it returned an error');
+  }
+};
+
+request.onerror = function() {
+    console.error('There was a connection error of some sort');
+};
+
+request.send();

--- a/en/docs/assets/js/sitheme.js
+++ b/en/docs/assets/js/sitheme.js
@@ -43,17 +43,16 @@ document.addEventListener('click', function (e) {
 var pageHeader = document.getElementById('page-header');
 var docSetLang = pageHeader ? pageHeader.getAttribute('data-lang') : '';
 
-(window.location.pathname.split('/')[1] !== docSetLang) ?
-    docSetLang = '' :
-    docSetLang = docSetLang + '/';
+if (docSetLang) {
+    docSetLang = (window.location.pathname.split('/')[1] === docSetLang)
+        ? docSetLang + '/'
+        : '';
+}
 
 var docSetUrl = window.location.origin + '/' + docSetLang;
 var request = new XMLHttpRequest();
 
-var isLocal = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
-var versionsUrl = isLocal
-    ? '/assets/versions.json'
-    : 'https://raw.githubusercontent.com/wso2/docs-si/versions/en/docs/assets/versions.json';
+var versionsUrl = 'https://raw.githubusercontent.com/wso2/docs-si/versions/en/docs/assets/versions.json';
 
 request.open('GET', versionsUrl, true);
 
@@ -74,6 +73,9 @@ request.onload = function() {
        * Appending versions to the version selector dropdown
        */
       if (dropdown) {
+          while (dropdown.children.length > 1) {
+              dropdown.removeChild(dropdown.firstChild);
+          }
           data.list.sort(function(a, b) {
               var aParts = a.split('.');
               var bParts = b.split('.');

--- a/en/docs/assets/js/sitheme.js
+++ b/en/docs/assets/js/sitheme.js
@@ -60,7 +60,13 @@ request.open('GET', versionsUrl, true);
 request.onload = function() {
   if (request.status >= 200 && request.status < 400) {
 
-      var data = JSON.parse(request.responseText);
+      var data;
+      try {
+          data = JSON.parse(request.responseText);
+      } catch (e) {
+          console.error('Failed to parse versions.json:', e);
+          return;
+      }
       var dropdown = document.getElementById('version-select-dropdown');
       var checkVersionsPage = document.getElementById('current-version-stable');
 
@@ -102,7 +108,10 @@ request.onload = function() {
                   }
                   url = url.replace(/\/$/, '') + searchAndHash;
 
-                  liElem.innerHTML = '<a href="' + url + '">' + key + '</a>';
+                  var aElem = document.createElement('a');
+                  aElem.setAttribute('href', url);
+                  aElem.textContent = key;
+                  liElem.appendChild(aElem);
 
                   dropdown.insertBefore(liElem, dropdown.firstChild);
               }
@@ -118,7 +127,7 @@ request.onload = function() {
        * Appending versions to the version tables in versions page
        */
       if (checkVersionsPage) {
-          var previousVersions = [];
+          var previousVersionsTbody = document.getElementById('previous-versions');
 
           Object.keys(data.all).forEach(function(key) {
               if ((key !== data.current) && (key !== data['pre-release'])) {
@@ -136,24 +145,45 @@ request.onload = function() {
                       notes = (docSetUrl + key + '/' + notes).replace(/([^:]\/)\/+/g, '$1');
                   }
 
-                  previousVersions.push('<tr>' +
-                      '<th>' + key + '</th>' +
-                      '<td><a href="' + doc + '" target="' + target + '">Documentation</a></td>' +
-                      '<td><a href="' + (notes || '#') + '" target="' + target + '">Release Notes</a></td>' +
-                      '</tr>');
+                  if (previousVersionsTbody) {
+                      var tr = document.createElement('tr');
+                      var th = document.createElement('th');
+                      th.textContent = key;
+                      var tdDoc = document.createElement('td');
+                      var aDoc = document.createElement('a');
+                      aDoc.setAttribute('href', doc);
+                      aDoc.setAttribute('target', target);
+                      aDoc.textContent = 'Documentation';
+                      tdDoc.appendChild(aDoc);
+                      var tdNotes = document.createElement('td');
+                      var aNotes = document.createElement('a');
+                      aNotes.setAttribute('href', notes || '#');
+                      aNotes.setAttribute('target', target);
+                      aNotes.textContent = 'Release Notes';
+                      tdNotes.appendChild(aNotes);
+                      tr.appendChild(th);
+                      tr.appendChild(tdDoc);
+                      tr.appendChild(tdNotes);
+                      previousVersionsTbody.appendChild(tr);
+                  }
               }
           });
 
-          document.getElementById('previous-versions').innerHTML = previousVersions.join(' ');
+          var currentVersionNum = document.getElementById('current-version-number');
+          if (currentVersionNum) {
+              currentVersionNum.textContent = data.current;
+          }
 
-          document.getElementById('current-version-number').innerHTML = data.current;
-          var docDocLink = docSetUrl + data.current;
-          var docNotesLink = data.all[data.current].notes
-              ? docSetUrl + data.all[data.current].notes
-              : docDocLink;
-
-          document.getElementById('current-version-documentation-link').setAttribute('href', docDocLink);
-          document.getElementById('current-version-release-notes-link').setAttribute('href', docNotesLink);
+          if (data.current && data.all[data.current]) {
+              var docDocLink = docSetUrl + data.current;
+              var docNotesLink = data.all[data.current].notes
+                  ? docSetUrl + data.all[data.current].notes
+                  : docDocLink;
+              var docLinkEl = document.getElementById('current-version-documentation-link');
+              var notesLinkEl = document.getElementById('current-version-release-notes-link');
+              if (docLinkEl) docLinkEl.setAttribute('href', docDocLink);
+              if (notesLinkEl) notesLinkEl.setAttribute('href', docNotesLink);
+          }
       }
 
   } else {

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -50,7 +50,7 @@ theme:
            name: Switch to light mode
     logo: assets/img/WSO2-logo-black.svg
     logo_light: assets/img/WSO2-logo-white.svg
-    favicon: assets/img/favicon.png
+    favicon: assets/img/WSO2-logo-orange.svg
     features:
        - navigation.indexes
        - navigation.path
@@ -348,6 +348,7 @@ extra_javascript:
     - assets/lib/highlightjs/highlight.min.js
     - assets/js/theme.js
     - assets/js/copy-page.js
+    - assets/js/sitheme.js
 extra:
     product_name: "WSO2 Integrator: SI"
     home_page_cards:
@@ -483,6 +484,6 @@ extra:
           link: https://www.youtube.com/user/WSO2TechFlicks
         - icon: fontawesome/brands/x-twitter
           link: https://twitter.com/intent/follow?screen_name=wso2
-    # site_version: Uncomment to specify a version
+    site_version: 4.4.0
     #base_path: http://localhost:8000/
     base_path: https://wso2.github.io/docs-si

--- a/en/theme/material/partials/header.html
+++ b/en/theme/material/partials/header.html
@@ -48,19 +48,15 @@
         </div>
       </div>
     </div>
-    <div class="md-flex__ellipsis md-header__version-select">
-      <div class="mb-tabs__dropdown version-select">
-        <a class="md-tabs__link md-tabs__dropdown-link" href="#!" data-target="version-select-dropdown">
-          {{ config.extra.site_version }}
-          <i class="fa-solid fa-angle-down"></i>
-        </a>
-        <ul id="version-select-dropdown" class="mb-tabs__dropdown-content" tabindex="0">
-          <!-- Versions will be added here dynamically -->
-          <li class="md-tabs__item mb-tabs__dropdown">
-            <a href="#" id="show-all-versions-link">Show all</a>
-          </li>
-        </ul>
-      </div>
+    <div class="md-header__version-select-dropdown" id="version-select-container">
+      <a class="dropdown-link" href="#!">
+        {{ config.extra.site_version }}
+        <span class="icon">{% include ".icons/material/chevron-down.svg" %}</span>
+      </a>
+      <ul class="dropdown-content" id="version-select-dropdown">
+        <!-- Versions will be added here dynamically -->
+        <li><a href="#" id="show-all-versions-link">Show all</a></li>
+      </ul>
     </div>
     {% if "material/search" in config.plugins and not page.is_homepage %}
     <label class="md-header__button md-icon" for="__search">

--- a/en/theme/material/partials/header.html
+++ b/en/theme/material/partials/header.html
@@ -55,7 +55,6 @@
       </a>
       <ul class="dropdown-content" id="version-select-dropdown">
         <!-- Versions will be added here dynamically -->
-        <li><a href="#" id="show-all-versions-link">Show all</a></li>
       </ul>
     </div>
     {% if "material/search" in config.plugins and not page.is_homepage %}

--- a/en/theme/material/partials/header.html
+++ b/en/theme/material/partials/header.html
@@ -22,7 +22,7 @@
 {% elif "navigation.tabs" not in features %}
 {% set class = class ~ " md-header--shadow" %}
 {% endif %}
-<header class="{{ class }}" data-md-component="header" id="page-header">
+<header class="{{ class }}" data-md-component="header" id="page-header" data-lang="{{ config.theme.language }}">
   <nav class="md-header__inner md-grid" aria-label="{{ lang.t('header') }}">
     <a href="{{ config.extra.homepage | d(nav.homepage.url, true) | url }}" title="{{ config.site_name | e }}"
       class="md-header__button md-logo" aria-label="{{ config.site_name }}" data-md-component="logo">
@@ -46,6 +46,20 @@
             {% endif %}
           </span>
         </div>
+      </div>
+    </div>
+    <div class="md-flex__ellipsis md-header__version-select">
+      <div class="mb-tabs__dropdown version-select">
+        <a class="md-tabs__link md-tabs__dropdown-link" href="#!" data-target="version-select-dropdown">
+          {{ config.extra.site_version }}
+          <i class="fa-solid fa-angle-down"></i>
+        </a>
+        <ul id="version-select-dropdown" class="mb-tabs__dropdown-content" tabindex="0">
+          <!-- Versions will be added here dynamically -->
+          <li class="md-tabs__item mb-tabs__dropdown">
+            <a href="#" id="show-all-versions-link">Show all</a>
+          </li>
+        </ul>
       </div>
     </div>
     {% if "material/search" in config.plugins and not page.is_homepage %}


### PR DESCRIPTION
## Summary
- Removed the "Show all" button from the version picker dropdown in `header.html`
- Removed the corresponding dead JS code that set its `href` in `sitheme.js`

## Test plan
- [ ] Open the version dropdown and confirm only version entries are shown (no "Show all" link)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)