### PR TITLE
Remove "Show all" button from version dropdown

### DIFF
--- a/en/docs/assets/js/sitheme.js
+++ b/en/docs/assets/js/sitheme.js
@@ -118,11 +118,6 @@ request.onload = function() {
                   dropdown.insertBefore(liElem, dropdown.firstChild);
               }
           });
-
-          var showAllLink = document.getElementById('show-all-versions-link');
-          if (showAllLink) {
-              showAllLink.setAttribute('href', docSetUrl + 'versions');
-          }
       }
 
       /*

--- a/en/theme/material/partials/header.html
+++ b/en/theme/material/partials/header.html
@@ -56,7 +56,6 @@
       </a>
       <ul class="dropdown-content" id="version-select-dropdown">
         <!-- Versions will be added here dynamically -->
-        <li><a href="#" id="show-all-versions-link">Show all</a></li>
       </ul>
     </div>
     {% if not config.theme.palette is mapping %}


### PR DESCRIPTION
## Summary
- Removed the "Show all" button from the version picker dropdown in `header.html`
- Removed the corresponding JS code that set its `href` in `sitheme.js`

## Test plan
- [ ] Open the version dropdown and confirm only version entries are shown (no "Show all" link)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)