### PR TITLE
Wire 4.3.1 branch into publish workflow

### DIFF
--- a/.github/workflows/publish_docs.yaml
+++ b/.github/workflows/publish_docs.yaml
@@ -8,6 +8,7 @@ on:
     branches:
       - main
       - 4.3.0
+      - 4.3.1
       - 4.4.0
   workflow_dispatch:
 
@@ -42,6 +43,9 @@ jobs:
           elif [ "$BRANCH_NAME" = "4.3.0" ]; then
             echo "Deploying 4.3.0 version from 4.3.0 branch"
             mike deploy 4.3.0 -t "4.3.0 and older" --push
+          elif [ "$BRANCH_NAME" = "4.3.1" ]; then
+            echo "Deploying 4.3.1 version from 4.3.1 branch"
+            mike deploy 4.3.1 -t "4.3.1" --push
           elif [ "$BRANCH_NAME" = "4.4.0" ]; then
             echo "Deploying 4.4.0 version from 4.4.0 branch"
             mike deploy 4.4.0 -t "4.4.0" --push


### PR DESCRIPTION
## Summary

Adds the newly created `4.3.1` branch into `.github/workflows/publish_docs.yaml`:

- Adds `4.3.1` under `on.push.branches`.
- Adds a deploy arm that runs `mike deploy 4.3.1 -t "4.3.1" --push` when the workflow is triggered from `4.3.1`.

The 4.3.1 branch was created as a snapshot of `main` so the 4.3.1 docs continue to be updatable after `main` becomes 4.4.0 (separate cutover PR). No alias is set from this arm — `latest` will be re-pointed to 4.4.0 in the cutover.

## Test plan
- [ ] Merging this PR triggers the workflow on the 4.3.1 branch.
- [ ] Workflow run logs show \`Deploying 4.3.1 version from 4.3.1 branch\`.
- [ ] After the run, \`/4.3.1/\` continues to serve 4.3.1 docs.
- [ ] The \`latest\` alias on \`gh-pages\` is untouched (\`git show origin/gh-pages:versions.json\` still shows 4.3.1 with \`latest\` until the cutover PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)