### PR TITLE
Make main publish 4.4.0 as latest

### DIFF
--- a/.github/workflows/publish_docs.yaml
+++ b/.github/workflows/publish_docs.yaml
@@ -8,7 +8,6 @@ on:
     branches:
       - main
       - 4.3.0
-      - 4.4.0
   workflow_dispatch:
 
 jobs:
@@ -36,15 +35,12 @@ jobs:
           git config --global user.name "ballerina-bot"
           cd en/
           if [ "$BRANCH_NAME" = "main" ]; then
-            echo "Deploying latest version from main branch"
-            mike deploy 4.3.1 latest -t "4.3.1" --push
+            echo "Deploying latest version (4.4.0) from main branch"
+            mike deploy 4.4.0 latest -t "4.4.0" --update-aliases --push
             mike set-default --push latest
           elif [ "$BRANCH_NAME" = "4.3.0" ]; then
             echo "Deploying 4.3.0 version from 4.3.0 branch"
             mike deploy 4.3.0 -t "4.3.0 and older" --push
-          elif [ "$BRANCH_NAME" = "4.4.0" ]; then
-            echo "Deploying 4.4.0 version from 4.4.0 branch"
-            mike deploy 4.4.0 -t "4.4.0" --push
           else
             echo "Unknown branch: $BRANCH_NAME"
             exit 1


### PR DESCRIPTION
## Summary

Sets up the publish workflow so that, after the upcoming **4.4.0 → main** cutover, pushes to \`main\` move the \`latest\` alias to 4.4.0:

- **\`main\` arm**: `mike deploy 4.4.0 latest -t "4.4.0" --update-aliases --push` + `mike set-default --push latest`. \`--update-aliases\` is required because mike refuses to silently move an existing alias.
- **Removed** the \`4.4.0\` push trigger and the \`elif [ "\$BRANCH_NAME" = "4.4.0" ]\` arm — after the cutover, \`main\` is the source of 4.4.0 publishes. Leaving the \`4.4.0\` trigger in place would risk a stray push re-running `mike deploy 4.4.0 -t "4.4.0" --push` and silently dropping the \`latest\` alias (mike preserves only explicitly passed aliases on re-deploys).

## Order in the release sequence

1. wso2/docs-si#85 — prep, independent.
2. wso2/docs-si#86 — wire 4.3.1 publish, independent.
3. **This PR** — merge into 4.4.0 before opening/merging the cutover PR.
4. Cutover PR: 4.4.0 → main (separate, opens after this merges).
5. Versions JSON update (separate).

## Test plan
- [ ] Merging this PR does NOT trigger a deploy (4.4.0 is no longer a push-trigger after this change).
- [ ] After the subsequent cutover PR merges into \`main\`, the workflow run from \`main\` logs \`Deploying latest version (4.4.0) from main branch\`.
- [ ] On \`gh-pages\`, \`versions.json\` shows 4.4.0 with \`"aliases": ["latest"]\` and 4.3.1 with \`"aliases": []\`.
- [ ] Visiting \`/\` redirects to \`/latest/\` and renders 4.4.0 content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)