### PR TITLE
Promote 4.4.0 to current in version dropdown

### DIFF
--- a/en/docs/assets/versions.json
+++ b/en/docs/assets/versions.json
@@ -1,22 +1,22 @@
 {
-    "current": "4.3.1",
+    "current": "4.4.0",
     "list": [
         "4.3.1",
         "4.3.0",
         "4.4.0"
     ],
     "all": {
-        "4.3.1": {
+        "4.4.0": {
             "doc": "latest",
             "notes": "latest/get-started/about-this-release"
+        },
+        "4.3.1": {
+            "doc": "4.3.1",
+            "notes": "4.3.1/get-started/about-this-release"
         },
         "4.3.0": {
             "doc": "4.3.0",
             "notes": "4.3.0/get-started/about-this-release"
-        },
-        "4.4.0": {
-            "doc": "4.4.0",
-            "notes": "4.4.0/get-started/about-this-release"
         }
     }
 }


### PR DESCRIPTION
## Summary

Updates \`en/docs/assets/versions.json\` (read live by \`sitheme.js\`) so the version picker reflects the \`/latest\` cutover to 4.4.0:

- \`current\`: \`"4.3.1"\` → \`"4.4.0"\`
- \`all["4.4.0"].doc\`: \`"4.4.0"\` → \`"latest"\`
- \`all["4.3.1"].doc\`: \`"latest"\` → \`"4.3.1"\`

### ⚠️ Draft — merge order

This PR is intentionally a **draft**. It should be marked ready and merged **only after** the cutover PR (wso2/docs-si#88) has merged and the resulting deploy has been verified — otherwise the dropdown would advertise a \`/latest/\` that still serves 4.3.1.

## Test plan
- [ ] Open any docs page after the cutover deploy completes; click the version selector.
- [ ] 4.4.0 is highlighted as current and the link resolves to \`/latest/...\`.
- [ ] 4.3.1 link resolves to \`/4.3.1/...\`; 4.3.0 link resolves to \`/4.3.0/...\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)