### PR TITLE
Fix broken images: point base_path to versioned URL

### DIFF
--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -491,4 +491,4 @@ extra:
           link: https://twitter.com/intent/follow?screen_name=wso2
     site_version: 4.4.0
     #base_path: http://localhost:8000/
-    base_path: https://wso2.github.io/docs-si
+    base_path: https://si.docs.wso2.com/4.4.0


### PR DESCRIPTION
## Summary

- `base_path` in `en/mkdocs.yml` was set to `https://wso2.github.io/docs-si`, which 301-redirects to the **unversioned** root of `si.docs.wso2.com`
- `mike` deploys assets only under `/<version>/`, so new images added in 4.4.0 had no copy at the unversioned root → 404
- Changed `base_path` to `https://si.docs.wso2.com/4.4.0` so all `{{base_path}}/images/...` references resolve to the versioned path where the assets actually exist

**Affected pages (8 broken images across 7 pages):**
- `get-started/quick-start-guide/` — 6 images
- `setup/installing-si-in-vm/` — 3 images
- `connectors/downloading-and-Installing-Siddhi-Extensions/` — 2 images
- `get-started/first-siddhi-app/create-the-siddhi-application/` — 1 image
- `develop/exporting-Siddhi-Applications/` — 1 image
- `get-started/first-siddhi-app/export-siddhi-application-as-docker/` — 1 image
- `get-started/first-siddhi-app/deploy-siddhi-application/` — 1 image

**Root cause note:** Older images happened to be present at the unversioned root from pre-mike deploys, masking the bug until new images were added in 4.4.0.

## Test plan

- [ ] Restart `mkdocs serve` and open `http://localhost:8000/get-started/quick-start-guide/` — all 6 screenshots should render
- [ ] Check the other 6 affected pages listed above
- [ ] After merge and deploy, verify `https://si.docs.wso2.com/4.4.0/get-started/quick-start-guide/` and `https://si.docs.wso2.com/latest/get-started/quick-start-guide/` show all images

🤖 Generated with [Claude Code](https://claude.com/claude-code)